### PR TITLE
Avoid deprecated ternary operator form

### DIFF
--- a/includes/wc-gzd-shipment-functions.php
+++ b/includes/wc-gzd-shipment-functions.php
@@ -517,7 +517,7 @@ function wc_gzd_return_shipment_reason_exists( $maybe_reason, $shipment = false 
  * @param ReturnReason $b
  */
 function _wc_gzd_sort_return_shipment_reasons( $a, $b ) {
-	return $a->get_order() == $b->get_order() ? 0 : ( $a->get_order() > $b->get_order() ) ? 1 : -1;
+	return $a->get_order() == $b->get_order() ? 0 : ( $a->get_order() > $b->get_order() ? 1 : -1 );
 }
 
 /**


### PR DESCRIPTION
PHP 7.4 deprecated the unparenthesized ternary operator, see
https://www.php.net/manual/en/migration74.deprecated.php. The notice
text is "Deprecated: Unparenthesized `a ? b : c ? d : e` is deprecated.
Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`".