### PR TITLE
Add possibility to update shipments

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -37,11 +37,11 @@ class Api {
             $order_shipment = wc_gzd_get_shipment_order( $order );
             $shipments      = $order_shipment->get_shipments();
 
-            if ( ! empty( $shipments ) ) {
-                foreach( $shipments as $shipment ) {
-                    $response_order_data['shipments'][] = ShipmentsController::prepare_shipment($shipment, 'view', $request['dp']);
-                }
-            }
+	        if ( ! empty( $shipments ) ) {
+		        foreach ( $shipments as $shipment ) {
+			        $response_order_data['shipments'][] = ShipmentsController::prepare_shipment( $shipment, 'view', $request['dp'] );
+		        }
+	        }
         }
 
         $response->set_data( $response_order_data );
@@ -50,21 +50,21 @@ class Api {
     }
 
     public static function order_shipments_schema( $schema ) {
-        $schema['shipments'] = array(
-            'description' => _x( 'List of shipments.', 'shipments', 'woocommerce-germanized-shipments' ),
-            'type'        => 'array',
-            'context'     => array( 'view', 'edit' ),
-            'readonly'    => true,
-            'items'       => ShipmentsController::get_single_item_schema(),
-        );
+	    $schema['shipments'] = array(
+		    'description' => _x( 'List of shipments.', 'shipments', 'woocommerce-germanized-shipments' ),
+		    'type'        => 'array',
+		    'context'     => array( 'view', 'edit' ),
+		    'readonly'    => true,
+		    'items'       => ShipmentsController::get_single_item_schema(),
+	    );
 
         return $schema;
     }
 
-    public static function register_controllers( $controller ) {
-        $controller['wc/v3']['shipments'] = ShipmentsController::class;
+	public static function register_controllers( $controller ) {
+		$controller['wc/v3']['shipments'] = ShipmentsController::class;
 
-        return $controller;
-    }
+		return $controller;
+	}
 
 }

--- a/src/Api.php
+++ b/src/Api.php
@@ -6,6 +6,7 @@
  */
 namespace Vendidero\Germanized\Shipments;
 
+use Vendidero\Germanized\Shipments\Rest\ShipmentsController;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -13,317 +14,57 @@ defined( 'ABSPATH' ) || exit;
 
 class Api {
 
-	public static function init() {
-		// add_filter( 'woocommerce_rest_api_get_rest_namespaces', array( __CLASS__, 'register_controllers' ) );
+    public static function init() {
+        add_filter( 'woocommerce_rest_api_get_rest_namespaces', array( __CLASS__, 'register_controllers' ) );
 
-		add_filter( 'woocommerce_rest_shop_order_schema', array( __CLASS__, 'order_shipments_schema' ), 10 );
-		add_filter( 'woocommerce_rest_prepare_shop_order_object', array( __CLASS__, 'prepare_order_shipments' ), 10, 3 );
-	}
+        add_filter( 'woocommerce_rest_shop_order_schema', array( __CLASS__, 'order_shipments_schema' ), 10 );
+        add_filter( 'woocommerce_rest_prepare_shop_order_object', array( __CLASS__, 'prepare_order_shipments' ), 10, 3 );
+    }
 
-	protected static function get_shipment_statuses() {
-		$statuses = array();
+    /**
+     * @param WP_REST_Response $response
+     * @param $post
+     * @param WP_REST_Request $request
+     *
+     * @return mixed
+     */
+    public static function prepare_order_shipments( $response, $post, $request ) {
+        $order                            = wc_get_order( $post );
+        $response_order_data              = $response->get_data();
+        $response_order_data['shipments'] = array();
 
-		foreach ( array_keys( wc_gzd_get_shipment_statuses() ) as $status ) {
-			$statuses[] = str_replace( 'gzd-', '', $status );
-		}
+        if ( $order ) {
+            $order_shipment = wc_gzd_get_shipment_order( $order );
+            $shipments      = $order_shipment->get_shipments();
 
-		return $statuses;
-	}
+            if ( ! empty( $shipments ) ) {
+                foreach( $shipments as $shipment ) {
+                    $response_order_data['shipments'][] = ShipmentsController::prepare_shipment($shipment, 'view', $request['dp']);
+                }
+            }
+        }
 
-	/**
-	 * @param WP_REST_Response $response
-	 * @param $post
-	 * @param WP_REST_Request $request
-	 *
-	 * @return mixed
-	 */
-	public static function prepare_order_shipments( $response, $post, $request ) {
-		$order                            = wc_get_order( $post );
-		$response_order_data              = $response->get_data();
-		$response_order_data['shipments'] = array();
-		$context                          = 'view';
+        $response->set_data( $response_order_data );
 
-		if ( $order ) {
-			$order_shipment = wc_gzd_get_shipment_order( $order );
-			$shipments      = $order_shipment->get_shipments();
+        return $response;
+    }
 
-			if ( ! empty( $shipments ) ) {
+    public static function order_shipments_schema( $schema ) {
+        $schema['shipments'] = array(
+            'description' => _x( 'List of shipments.', 'shipments', 'woocommerce-germanized-shipments' ),
+            'type'        => 'array',
+            'context'     => array( 'view', 'edit' ),
+            'readonly'    => true,
+            'items'       => ShipmentsController::get_single_item_schema(),
+        );
 
-				foreach( $shipments as $shipment ) {
+        return $schema;
+    }
 
-					$item_data = array();
+    public static function register_controllers( $controller ) {
+        $controller['wc/v3']['shipments'] = ShipmentsController::class;
 
-					foreach( $shipment->get_items() as $item ) {
-						$item_data[] = array(
-							'id'            => $item->get_id(),
-							'name'          => $item->get_name( $context ),
-							'order_item_id' => $item->get_order_item_id( $context ),
-							'product_id'    => $item->get_product_id( $context ),
-							'quantity'      => $item->get_quantity( $context ),
-						);
-					}
+        return $controller;
+    }
 
-					$shipment_data = array(
-						'id'                    => $shipment->get_id(),
-						'date_created'          => wc_rest_prepare_date_response( $shipment->get_date_created( $context ), false ),
-						'date_created_gmt'      => wc_rest_prepare_date_response( $shipment->get_date_created( $context ) ),
-						'date_sent'             => wc_rest_prepare_date_response( $shipment->get_date_sent( $context ), false ),
-						'date_sent_gmt'         => wc_rest_prepare_date_response( $shipment->get_date_sent( $context ) ),
-						'est_delivery_date'     => wc_rest_prepare_date_response( $shipment->get_est_delivery_date( $context ), false ),
-						'est_delivery_date_gmt' => wc_rest_prepare_date_response( $shipment->get_est_delivery_date( $context ) ),
-						'total'                 => wc_format_decimal( $shipment->get_total(), $request['dp'] ),
-						'weight'                => $shipment->get_weight( $context ),
-						'status'                => $shipment->get_status(),
-						'tracking_id'           => $shipment->get_tracking_id(),
-						'tracking_url'          => $shipment->get_tracking_url(),
-						'shipping_provider'     => $shipment->get_shipping_provider(),
-						'dimensions'            => array(
-							'length' => $shipment->get_length( $context ),
-							'width'  => $shipment->get_width( $context ),
-							'height' => $shipment->get_height( $context ),
-						),
-						'address'               => $shipment->get_address( $context ),
-						'items'                 => $item_data,
-					);
-
-					$response_order_data['shipments'][] = $shipment_data;
-				}
-			}
-		}
-
-		$response->set_data( $response_order_data );
-
-		return $response;
-	}
-
-	public static function order_shipments_schema( $schema ) {
-		$weight_unit    = get_option( 'woocommerce_weight_unit' );
-		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
-
-		$schema['shipments'] = array(
-			'description' => _x( 'List of shipments.', 'shipments', 'woocommerce-germanized-shipments' ),
-			'type'        => 'array',
-			'context'     => array( 'view', 'edit' ),
-			'readonly'    => true,
-			'items'       => array(
-				'type'       => 'object',
-				'properties' => array(
-					'id'     => array(
-						'description' => _x( 'Shipment ID.', 'shipments', 'woocommerce-germanized-shipments' ),
-						'type'        => 'integer',
-						'context'     => array( 'view', 'edit' ),
-						'readonly'    => true,
-					),
-					'status' => array(
-						'description' => _x( 'Shipment status.', 'shipments', 'woocommerce-germanized-shipments' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'enum'        => self::get_shipment_statuses(),
-						'readonly'    => true,
-					),
-					'tracking_id' => array(
-						'description' => _x( 'Shipment tracking id.', 'shipments', 'woocommerce-germanized-shipments' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'readonly'    => true,
-					),
-					'tracking_url' => array(
-						'description' => _x( 'Shipment tracking url.', 'shipments', 'woocommerce-germanized-shipments' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'readonly'    => true,
-					),
-					'shipping_provider' => array(
-						'description' => _x( 'Shipment shipping provider.', 'shipments', 'woocommerce-germanized-shipments' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'readonly'    => true,
-					),
-					'date_created'         => array(
-						'description' => _x( "The date the shipment was created, in the site's timezone.", 'shipments', 'woocommerce-germanized-shipments' ),
-						'type'        => 'date-time',
-						'context'     => array( 'view', 'edit' ),
-						'readonly'    => true,
-					),
-					'date_created_gmt'     => array(
-						'description' => _x( 'The date the shipment was created, as GMT.', 'shipments', 'woocommerce-germanized-shipments' ),
-						'type'        => 'date-time',
-						'context'     => array( 'view', 'edit' ),
-						'readonly'    => true,
-					),
-					'date_sent'         => array(
-						'description' => _x( "The date the shipment was sent, in the site's timezone.", 'shipments', 'woocommerce-germanized-shipments' ),
-						'type'        => 'date-time',
-						'context'     => array( 'view', 'edit' ),
-						'readonly'    => true,
-					),
-					'date_sent_gmt'     => array(
-						'description' => _x( 'The date the shipment was sent, as GMT.', 'shipments', 'woocommerce-germanized-shipments' ),
-						'type'        => 'date-time',
-						'context'     => array( 'view', 'edit' ),
-						'readonly'    => true,
-					),
-					'est_delivery_date' => array(
-						'description' => _x( "The estimated delivery date of the shipment, in the site's timezone.", 'shipments', 'woocommerce-germanized-shipments' ),
-						'type'        => 'date-time',
-						'context'     => array( 'view', 'edit' ),
-						'readonly'    => true,
-					),
-					'est_delivery_date_gmt'     => array(
-						'description' => _x( 'The estimated delivery date of the shipment, as GMT.', 'shipments', 'woocommerce-germanized-shipments' ),
-						'type'        => 'date-time',
-						'context'     => array( 'view', 'edit' ),
-						'readonly'    => true,
-					),
-					'weight'                => array(
-						/* translators: %s: weight unit */
-						'description' => sprintf( _x( 'Shipment weight (%s).', 'shipments', 'woocommerce-germanized-shipments' ), $weight_unit ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'readonly'    => true,
-					),
-					'dimensions'            => array(
-						'description' => _x( 'Shipment dimensions.', 'shipments', 'woocommerce-germanized-shipments' ),
-						'type'        => 'object',
-						'context'     => array( 'view', 'edit' ),
-						'readonly'    => true,
-						'properties'  => array(
-							'length' => array(
-								/* translators: %s: dimension unit */
-								'description' => sprintf( _x( 'Shipment length (%s).', 'shipments', 'woocommerce-germanized-shipments' ), $dimension_unit ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'width'  => array(
-								/* translators: %s: dimension unit */
-								'description' => sprintf( _x( 'Shipment width (%s).', 'shipments', 'woocommerce-germanized-shipments' ), $dimension_unit ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'height' => array(
-								/* translators: %s: dimension unit */
-								'description' => sprintf( _x( 'Shipment height (%s).', 'shipments', 'woocommerce-germanized-shipments' ), $dimension_unit ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-						),
-					),
-					'address'         => array(
-						'description' => _x( 'Shipping address.', 'shipments', 'woocommerce-germanized-shipments' ),
-						'type'        => 'object',
-						'context'     => array( 'view', 'edit' ),
-						'readonly'    => true,
-						'properties'  => array(
-							'first_name' => array(
-								'description' => _x( 'First name.', 'shipments', 'woocommerce-germanized-shipments' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'last_name'  => array(
-								'description' => _x( 'Last name.', 'shipments', 'woocommerce-germanized-shipments' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'company'    => array(
-								'description' => _x( 'Company name.', 'shipments', 'woocommerce-germanized-shipments' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'address_1'  => array(
-								'description' => _x( 'Address line 1', 'shipments', 'woocommerce-germanized-shipments' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'address_2'  => array(
-								'description' => _x( 'Address line 2', 'shipments', 'woocommerce-germanized-shipments' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'city'       => array(
-								'description' => _x( 'City name.', 'shipments', 'woocommerce-germanized-shipments' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'state'      => array(
-								'description' => _x( 'ISO code or name of the state, province or district.', 'shipments', 'woocommerce-germanized-shipments' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'postcode'   => array(
-								'description' => _x( 'Postal code.', 'shipments', 'woocommerce-germanized-shipments' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'country'    => array(
-								'description' => _x( 'Country code in ISO 3166-1 alpha-2 format.', 'shipments', 'woocommerce-germanized-shipments' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-						),
-					),
-					'items'           => array(
-						'description' => _x( 'Shipment items.', 'shipments', 'woocommerce-germanized-shipments' ),
-						'type'        => 'array',
-						'context'     => array( 'view', 'edit' ),
-						'readonly'    => true,
-						'items'       => array(
-							'type'       => 'object',
-							'properties' => array(
-								'id'           => array(
-									'description' => _x( 'Item ID.', 'shipments', 'woocommerce-germanized-shipments' ),
-									'type'        => 'integer',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'name'         => array(
-									'description' => _x( 'Item name.', 'shipments', 'woocommerce-germanized-shipments' ),
-									'type'        => 'mixed',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'order_item_id'   => array(
-									'description' => _x( 'Order Item ID.', 'shipments', 'woocommerce-germanized-shipments' ),
-									'type'        => 'integer',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'product_id'   => array(
-									'description' => _x( 'Product ID.', 'shipments', 'woocommerce-germanized-shipments' ),
-									'type'        => 'mixed',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'quantity'     => array(
-									'description' => _x( 'Quantity.', 'shipments', 'woocommerce-germanized-shipments' ),
-									'type'        => 'integer',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-							),
-						),
-					),
-				),
-			),
-		);
-
-		return $schema;
-	}
-
-	public static function register_controllers( $controller ) {
-		$controller['wc/v3']['shipments'] = 'Vendidero\Germanized\Shipments\Rest\Shipments.php';
-
-		return $controller;
-	}
 }

--- a/src/Rest/ShipmentsController.php
+++ b/src/Rest/ShipmentsController.php
@@ -11,460 +11,566 @@ use WP_REST_Server;
 
 defined( 'ABSPATH' ) || exit;
 
-class ShipmentsController extends WC_REST_Controller
-{
+class ShipmentsController extends WC_REST_Controller {
 
-    /**
-     * Endpoint namespace.
-     *
-     * @var string
-     */
-    protected $namespace = 'wc/v3';
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
 
-    /**
-     * Route base.
-     *
-     * @var string
-     */
-    protected $rest_base = 'orders/(?P<order_id>[\d]+)/shipments';
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'orders/(?P<order_id>[\d]+)/shipments';
 
-    /**
-     * Registers rest routes for this controller.
-     */
-    public function register_routes()
-    {
-        register_rest_route(
-            $this->namespace,
-            '/' . $this->rest_base,
-            array(
-                array(
-                    'methods'             => WP_REST_Server::READABLE,
-                    'callback'            => array( $this, 'get_items' ),
-                    'permission_callback' => array( $this, 'get_items_permissions_check' ),
-                    'args'                => $this->get_collection_params(),
-                ),
-                'schema' => array( $this, 'get_public_item_schema' ),
-            ),
-        );
-        register_rest_route(
-            $this->namespace,
-            '/' . $this->rest_base . '/(?P<id>[\d]+)',
-            array(
-                array(
-                    'methods'             => WP_REST_Server::READABLE,
-                    'callback'            => array( $this, 'get_item' ),
-                    'permission_callback' => array( $this, 'get_item_permissions_check' ),
-                    'args'                => array(
-                        'context' => $this->get_context_param( array( 'default' => 'view' ) ),
-                    ),
-                ),
-                array(
-                    'methods'             => WP_REST_Server::EDITABLE,
-                    'callback'            => array( $this, 'update_item' ),
-                    'permission_callback' => array( $this, 'update_item_permissions_check' ),
-                    'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
-                ),
-                'schema' => array( $this, 'get_public_item_schema' ),
-            ),
-        );
-    }
+	/**
+	 * Registers rest routes for this controller.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			),
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			),
+		);
+	}
 
-    private static function get_shipment_statuses() {
-        $statuses = array();
+	private static function get_shipment_statuses() {
+		$statuses = array();
 
-        foreach ( array_keys( wc_gzd_get_shipment_statuses() ) as $status ) {
-            $statuses[] = str_replace( 'gzd-', '', $status );
-        }
+		foreach ( array_keys( wc_gzd_get_shipment_statuses() ) as $status ) {
+			$statuses[] = str_replace( 'gzd-', '', $status );
+		}
 
-        return $statuses;
-    }
+		return $statuses;
+	}
 
-    /**
-     * Checks if a given request has access to get a specific item.
-     *
-     * @since 4.7.0
-     *
-     * @param WP_REST_Request $request Full details about the request.
-     * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
-     */
-    public function get_item_permissions_check($request)
-    {
-        return true;
-    }
+	/**
+	 * Checks if a given request has access to get a specific item.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+	 * @since 4.7.0
+	 */
+	public function get_item_permissions_check( $request ) {
+		$order = wc_get_order( (int) $request['order_id'] );
 
-    /**
-     * Retrieves one item from the collection.
-     *
-     * @since 4.7.0
-     *
-     * @param WP_REST_Request $request Full details about the request.
-     * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-     */
-    public function get_item($request)
-    {
-        $order = wc_get_order((int)$request['order_id']);
+		if ( $order && 0 !== $order->get_id() && ! wc_rest_check_post_permissions( 'shop_order',
+				'read',
+				$order->get_id() ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view',
+				__( 'Sorry, you cannot view this resource.', 'woocommerce' ),
+				array( 'status' => rest_authorization_required_code() ) );
+		}
 
-        $shipment = null;
-        if ($order) {
-            $order_shipment = wc_gzd_get_shipment_order($order);
-            $shipment = $order_shipment->get_shipment((int)$request['id']);
-            if (!$shipment) {
-                $shipment = new WP_Error(404, 'Not found');
-            } else {
-                $shipment = self::prepare_shipment($shipment);
-            }
-        }
+		return true;
+	}
 
-        $response = rest_ensure_response( $shipment );
+	/**
+	 * Retrieves a shipment by an order id and shipment id
+	 *
+	 * @param int $order_id
+	 * @param int $shipment_id
+	 *
+	 * @return Shipment|null
+	 */
+	private function get_shipment( int $order_id, int $shipment_id ): ?Shipment {
+		$order = wc_get_order( $order_id );
 
-        return $response;
-    }
+		$shipment = null;
+		if ( $order ) {
+			$order_shipment = wc_gzd_get_shipment_order( $order );
+			$shipment       = $order_shipment->get_shipment( $shipment_id );
+		}
 
-    /**
-     * Checks if a given request has access to get a specific item.
-     *
-     * @since 4.7.0
-     *
-     * @param WP_REST_Request $request Full details about the request.
-     * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
-     */
-    public function get_items_permissions_check($request)
-    {
-        return true;
-    }
+		return $shipment;
+	}
 
-    /**
-     * Retrieves a collection of items.
-     *
-     * @since 4.7.0
-     *
-     * @param WP_REST_Request $request Full details about the request.
-     * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-     */
-    public function get_items($request)
-    {
-        $order = wc_get_order((int)$request['order_id']);
+	/**
+	 * Retrieves one item from the collection.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 * @since 4.7.0
+	 */
+	public function get_item( $request ) {
+		$shipment      = $this->get_shipment( (int) $request['order_id'], (int) $request['id'] );
+		$shipment_data = $shipment === null
+			? new WP_Error( 404, 'Not found' )
+			: self::prepare_shipment( $shipment );
 
-        $result = array();
-        if ($order) {
-            $order_shipment = wc_gzd_get_shipment_order($order);
-            $shipments = $order_shipment->get_shipments();
+		return rest_ensure_response( $shipment_data );
+	}
 
-            if ( ! empty( $shipments ) ) {
+	/**
+	 * Checks if a given request has access to get a specific item.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+	 * @since 4.7.0
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! wc_rest_check_post_permissions( 'shop_order', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view',
+				__( 'Sorry, you cannot list resources.', 'woocommerce' ),
+				array( 'status' => rest_authorization_required_code() ) );
+		}
 
-                foreach( $shipments as $shipment ) {
-                    $result[] = $this->prepare_shipment($shipment);
-                }
-            }
-        }
+		return true;
+	}
 
-        $response = rest_ensure_response( $result );
+	/**
+	 * Retrieves a collection of items.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 * @since 4.7.0
+	 */
+	public function get_items( $request ) {
+		$order = wc_get_order( (int) $request['order_id'] );
 
-        return $response;
-    }
+		$result = array();
+		if ( $order ) {
+			$order_shipment = wc_gzd_get_shipment_order( $order );
+			$shipments      = $order_shipment->get_shipments();
 
-    /**
-     * Checks if a given request has access to update a specific item.
-     *
-     * @since 4.7.0
-     *
-     * @param WP_REST_Request $request Full details about the request.
-     * @return true|WP_Error True if the request has access to update the item, WP_Error object otherwise.
-     */
-    public function update_item_permissions_check($request)
-    {
-        return true;
-    }
+			if ( ! empty( $shipments ) ) {
+				foreach ( $shipments as $shipment ) {
+					$result[] = $this->prepare_shipment( $shipment );
+				}
+			}
+		}
 
-    /**
-     * Updates one item from the collection.
-     *
-     * @since 4.7.0
-     *
-     * @param WP_REST_Request $request Full details about the request.
-     * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-     */
-    public function update_item($request)
-    {
-    }
+		return rest_ensure_response( $result );
+	}
 
-    /**
-     * Retrieves the item's schema, conforming to JSON Schema.
-     *
-     * @since 4.7.0
-     *
-     * @return array Item schema data.
-     */
-    public function get_item_schema() {
-        return $this->add_additional_fields_schema(self::get_single_item_schema());
-    }
+	/**
+	 * Checks if a given request has access to update a specific item.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return true|WP_Error True if the request has access to update the item, WP_Error object otherwise.
+	 * @since 4.7.0
+	 */
+	public function update_item_permissions_check( $request ) {
+		$order = wc_get_order( (int) $request['order_id'] );
 
-    /**
-     * @param Shipment $shipment
-     *
-     * @return array
-     */
-    public static function prepare_shipment(Shipment $shipment, string $context = 'view', $dp = false): array {
-        $item_data = array();
+		if ( $order && 0 !== $order->get_id() && ! wc_rest_check_post_permissions( 'shop_order',
+				'edit',
+				$order->get_id() ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_edit',
+				__( 'Sorry, you are not allowed to edit this resource.', 'woocommerce' ),
+				array( 'status' => rest_authorization_required_code() ) );
+		}
 
-        foreach( $shipment->get_items() as $item ) {
-            $item_data[] = array(
-                'id'            => $item->get_id(),
-                'name'          => $item->get_name( $context ),
-                'order_item_id' => $item->get_order_item_id( $context ),
-                'product_id'    => $item->get_product_id( $context ),
-                'quantity'      => $item->get_quantity( $context ),
-            );
-        }
+		return true;
+	}
 
-        return array(
-            'id'                    => $shipment->get_id(),
-            'date_created'          => wc_rest_prepare_date_response( $shipment->get_date_created( $context ), false ),
-            'date_created_gmt'      => wc_rest_prepare_date_response( $shipment->get_date_created( $context ) ),
-            'date_sent'             => wc_rest_prepare_date_response( $shipment->get_date_sent( $context ), false ),
-            'date_sent_gmt'         => wc_rest_prepare_date_response( $shipment->get_date_sent( $context ) ),
-            'est_delivery_date'     => wc_rest_prepare_date_response( $shipment->get_est_delivery_date( $context ), false ),
-            'est_delivery_date_gmt' => wc_rest_prepare_date_response( $shipment->get_est_delivery_date( $context ) ),
-            'total'                 => wc_format_decimal( $shipment->get_total(), $dp ),
-            'weight'                => $shipment->get_weight( $context ),
-            'status'                => $shipment->get_status(),
-            'tracking_id'           => $shipment->get_tracking_id(),
-            'tracking_url'          => $shipment->get_tracking_url(),
-            'shipping_provider'     => $shipment->get_shipping_provider(),
-            'dimensions'            => array(
-                'length' => $shipment->get_length( $context ),
-                'width'  => $shipment->get_width( $context ),
-                'height' => $shipment->get_height( $context ),
-            ),
-            'address'               => $shipment->get_address( $context ),
-            'items'                 => $item_data,
-        );
-    }
+	/**
+	 * Updates one item from the collection.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 * @since 4.7.0
+	 */
+	public function update_item( $request ) {
+		$shipment = $this->get_shipment( (int) $request['order_id'], (int) $request['id'] );
 
-    /**
-     * Get the schema of a single shipment
-     *
-     * @return array
-     */
-    public static function get_single_item_schema(): array
-    {
-        $weight_unit    = get_option( 'woocommerce_weight_unit' );
-        $dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$json_params = $request->get_json_params();
 
-        return array(
-            'description' => _x( 'Single shipment.', 'shipment', 'woocommerce-germanized-shipments' ),
-            'context'     => array( 'view', 'edit' ),
-            'readonly'    => false,
-            'type'       => 'object',
-            'properties' => array(
-                'id'     => array(
-                    'description' => _x( 'Shipment ID.', 'shipments', 'woocommerce-germanized-shipments' ),
-                    'type'        => 'integer',
-                    'context'     => array( 'view', 'edit' ),
-                    'readonly'    => true,
-                ),
-                'status' => array(
-                    'description' => _x( 'Shipment status.', 'shipments', 'woocommerce-germanized-shipments' ),
-                    'type'        => 'string',
-                    'context'     => array( 'view', 'edit' ),
-                    'enum'        => self::get_shipment_statuses(),
-                    'readonly'    => true,
-                ),
-                'tracking_id' => array(
-                    'description' => _x( 'Shipment tracking id.', 'shipments', 'woocommerce-germanized-shipments' ),
-                    'type'        => 'string',
-                    'context'     => array( 'view', 'edit' ),
-                    'readonly'    => true,
-                ),
-                'tracking_url' => array(
-                    'description' => _x( 'Shipment tracking url.', 'shipments', 'woocommerce-germanized-shipments' ),
-                    'type'        => 'string',
-                    'context'     => array( 'view', 'edit' ),
-                    'readonly'    => true,
-                ),
-                'shipping_provider' => array(
-                    'description' => _x( 'Shipment shipping provider.', 'shipments', 'woocommerce-germanized-shipments' ),
-                    'type'        => 'string',
-                    'context'     => array( 'view', 'edit' ),
-                    'readonly'    => true,
-                ),
-                'date_created'         => array(
-                    'description' => _x( "The date the shipment was created, in the site's timezone.", 'shipments', 'woocommerce-germanized-shipments' ),
-                    'type'        => 'date-time',
-                    'context'     => array( 'view', 'edit' ),
-                    'readonly'    => true,
-                ),
-                'date_created_gmt'     => array(
-                    'description' => _x( 'The date the shipment was created, as GMT.', 'shipments', 'woocommerce-germanized-shipments' ),
-                    'type'        => 'date-time',
-                    'context'     => array( 'view', 'edit' ),
-                    'readonly'    => true,
-                ),
-                'date_sent'         => array(
-                    'description' => _x( "The date the shipment was sent, in the site's timezone.", 'shipments', 'woocommerce-germanized-shipments' ),
-                    'type'        => 'date-time',
-                    'context'     => array( 'view', 'edit' ),
-                    'readonly'    => true,
-                ),
-                'date_sent_gmt'     => array(
-                    'description' => _x( 'The date the shipment was sent, as GMT.', 'shipments', 'woocommerce-germanized-shipments' ),
-                    'type'        => 'date-time',
-                    'context'     => array( 'view', 'edit' ),
-                    'readonly'    => true,
-                ),
-                'est_delivery_date' => array(
-                    'description' => _x( "The estimated delivery date of the shipment, in the site's timezone.", 'shipments', 'woocommerce-germanized-shipments' ),
-                    'type'        => 'date-time',
-                    'context'     => array( 'view', 'edit' ),
-                    'readonly'    => true,
-                ),
-                'est_delivery_date_gmt'     => array(
-                    'description' => _x( 'The estimated delivery date of the shipment, as GMT.', 'shipments', 'woocommerce-germanized-shipments' ),
-                    'type'        => 'date-time',
-                    'context'     => array( 'view', 'edit' ),
-                    'readonly'    => true,
-                ),
-                'weight'                => array(
-                    /* translators: %s: weight unit */
-                    'description' => sprintf( _x( 'Shipment weight (%s).', 'shipments', 'woocommerce-germanized-shipments' ), $weight_unit ),
-                    'type'        => 'string',
-                    'context'     => array( 'view', 'edit' ),
-                    'readonly'    => true,
-                ),
-                'dimensions'            => array(
-                    'description' => _x( 'Shipment dimensions.', 'shipments', 'woocommerce-germanized-shipments' ),
-                    'type'        => 'object',
-                    'context'     => array( 'view', 'edit' ),
-                    'readonly'    => true,
-                    'properties'  => array(
-                        'length' => array(
-                            /* translators: %s: dimension unit */
-                            'description' => sprintf( _x( 'Shipment length (%s).', 'shipments', 'woocommerce-germanized-shipments' ), $dimension_unit ),
-                            'type'        => 'string',
-                            'context'     => array( 'view', 'edit' ),
-                            'readonly'    => true,
-                        ),
-                        'width'  => array(
-                            /* translators: %s: dimension unit */
-                            'description' => sprintf( _x( 'Shipment width (%s).', 'shipments', 'woocommerce-germanized-shipments' ), $dimension_unit ),
-                            'type'        => 'string',
-                            'context'     => array( 'view', 'edit' ),
-                            'readonly'    => true,
-                        ),
-                        'height' => array(
-                            /* translators: %s: dimension unit */
-                            'description' => sprintf( _x( 'Shipment height (%s).', 'shipments', 'woocommerce-germanized-shipments' ), $dimension_unit ),
-                            'type'        => 'string',
-                            'context'     => array( 'view', 'edit' ),
-                            'readonly'    => true,
-                        ),
-                    ),
-                ),
-                'address'         => array(
-                    'description' => _x( 'Shipping address.', 'shipments', 'woocommerce-germanized-shipments' ),
-                    'type'        => 'object',
-                    'context'     => array( 'view', 'edit' ),
-                    'readonly'    => true,
-                    'properties'  => array(
-                        'first_name' => array(
-                            'description' => _x( 'First name.', 'shipments', 'woocommerce-germanized-shipments' ),
-                            'type'        => 'string',
-                            'context'     => array( 'view', 'edit' ),
-                            'readonly'    => true,
-                        ),
-                        'last_name'  => array(
-                            'description' => _x( 'Last name.', 'shipments', 'woocommerce-germanized-shipments' ),
-                            'type'        => 'string',
-                            'context'     => array( 'view', 'edit' ),
-                            'readonly'    => true,
-                        ),
-                        'company'    => array(
-                            'description' => _x( 'Company name.', 'shipments', 'woocommerce-germanized-shipments' ),
-                            'type'        => 'string',
-                            'context'     => array( 'view', 'edit' ),
-                            'readonly'    => true,
-                        ),
-                        'address_1'  => array(
-                            'description' => _x( 'Address line 1', 'shipments', 'woocommerce-germanized-shipments' ),
-                            'type'        => 'string',
-                            'context'     => array( 'view', 'edit' ),
-                            'readonly'    => true,
-                        ),
-                        'address_2'  => array(
-                            'description' => _x( 'Address line 2', 'shipments', 'woocommerce-germanized-shipments' ),
-                            'type'        => 'string',
-                            'context'     => array( 'view', 'edit' ),
-                            'readonly'    => true,
-                        ),
-                        'city'       => array(
-                            'description' => _x( 'City name.', 'shipments', 'woocommerce-germanized-shipments' ),
-                            'type'        => 'string',
-                            'context'     => array( 'view', 'edit' ),
-                            'readonly'    => true,
-                        ),
-                        'state'      => array(
-                            'description' => _x( 'ISO code or name of the state, province or district.', 'shipments', 'woocommerce-germanized-shipments' ),
-                            'type'        => 'string',
-                            'context'     => array( 'view', 'edit' ),
-                            'readonly'    => true,
-                        ),
-                        'postcode'   => array(
-                            'description' => _x( 'Postal code.', 'shipments', 'woocommerce-germanized-shipments' ),
-                            'type'        => 'string',
-                            'context'     => array( 'view', 'edit' ),
-                            'readonly'    => true,
-                        ),
-                        'country'    => array(
-                            'description' => _x( 'Country code in ISO 3166-1 alpha-2 format.', 'shipments', 'woocommerce-germanized-shipments' ),
-                            'type'        => 'string',
-                            'context'     => array( 'view', 'edit' ),
-                            'readonly'    => true,
-                        ),
-                    ),
-                ),
-                'items'           => array(
-                    'description' => _x( 'Shipment items.', 'shipments', 'woocommerce-germanized-shipments' ),
-                    'type'        => 'array',
-                    'context'     => array( 'view', 'edit' ),
-                    'readonly'    => true,
-                    'items'       => array(
-                        'type'       => 'object',
-                        'properties' => array(
-                            'id'           => array(
-                                'description' => _x( 'Item ID.', 'shipments', 'woocommerce-germanized-shipments' ),
-                                'type'        => 'integer',
-                                'context'     => array( 'view', 'edit' ),
-                                'readonly'    => true,
-                            ),
-                            'name'         => array(
-                                'description' => _x( 'Item name.', 'shipments', 'woocommerce-germanized-shipments' ),
-                                'type'        => 'mixed',
-                                'context'     => array( 'view', 'edit' ),
-                                'readonly'    => true,
-                            ),
-                            'order_item_id'   => array(
-                                'description' => _x( 'Order Item ID.', 'shipments', 'woocommerce-germanized-shipments' ),
-                                'type'        => 'integer',
-                                'context'     => array( 'view', 'edit' ),
-                                'readonly'    => true,
-                            ),
-                            'product_id'   => array(
-                                'description' => _x( 'Product ID.', 'shipments', 'woocommerce-germanized-shipments' ),
-                                'type'        => 'mixed',
-                                'context'     => array( 'view', 'edit' ),
-                                'readonly'    => true,
-                            ),
-                            'quantity'     => array(
-                                'description' => _x( 'Quantity.', 'shipments', 'woocommerce-germanized-shipments' ),
-                                'type'        => 'integer',
-                                'context'     => array( 'view', 'edit' ),
-                                'readonly'    => true,
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-        );
-    }
+		$args = [];
+		if ( array_key_exists( 'weight',
+				$json_params ) && $shipment->get_weight( 'view' ) !== $json_params['weight'] ) {
+			$args['weight'] = $json_params['weight'];
+		}
+
+		$new_status = isset( $json_params['status'] ) ? str_replace( 'gzd-',
+			'',
+			wc_clean( wp_unslash( $json_params['status'] ) ) ) : 'draft';
+		if ( $new_status !== $shipment->get_status( 'view' ) ) {
+			$args['status'] = $new_status;
+		}
+
+		// Sync the shipment - make sure gets refresh on status switch (e.g. from shipped to processing)
+		if (
+			! empty( $args ) && (
+				$shipment->is_editable() ||
+				in_array( $new_status, wc_gzd_get_shipment_editable_statuses() ) ||
+				array_keys( $args ) === [ 'status' ]
+			)
+		) {
+			$shipment->sync( $args );
+			$shipment->save();
+		} elseif ( ! empty( $args ) ) {
+			return rest_ensure_response( new WP_Error( 422, 'Shipment not editable' ) );
+		}
+
+		return $this->get_item( $request );
+	}
+
+	/**
+	 * Retrieves the item's schema, conforming to JSON Schema.
+	 *
+	 * @return array Item schema data.
+	 * @since 4.7.0
+	 */
+	public function get_item_schema() {
+		return $this->add_additional_fields_schema( self::get_single_item_schema() );
+	}
+
+	/**
+	 * @param Shipment $shipment
+	 * @param string $context
+	 * @param bool|int $dp
+	 *
+	 * @return array
+	 */
+	public static function prepare_shipment( Shipment $shipment, string $context = 'view', $dp = false ): array {
+		$item_data = array();
+
+		foreach ( $shipment->get_items() as $item ) {
+			$item_data[] = array(
+				'id'            => $item->get_id(),
+				'name'          => $item->get_name( $context ),
+				'order_item_id' => $item->get_order_item_id( $context ),
+				'product_id'    => $item->get_product_id( $context ),
+				'quantity'      => $item->get_quantity( $context ),
+			);
+		}
+
+		return array(
+			'id'                    => $shipment->get_id(),
+			'date_created'          => wc_rest_prepare_date_response( $shipment->get_date_created( $context ), false ),
+			'date_created_gmt'      => wc_rest_prepare_date_response( $shipment->get_date_created( $context ) ),
+			'date_sent'             => wc_rest_prepare_date_response( $shipment->get_date_sent( $context ), false ),
+			'date_sent_gmt'         => wc_rest_prepare_date_response( $shipment->get_date_sent( $context ) ),
+			'est_delivery_date'     => wc_rest_prepare_date_response( $shipment->get_est_delivery_date( $context ),
+				false ),
+			'est_delivery_date_gmt' => wc_rest_prepare_date_response( $shipment->get_est_delivery_date( $context ) ),
+			'total'                 => wc_format_decimal( $shipment->get_total(), $dp ),
+			'weight'                => $shipment->get_weight( $context ),
+			'status'                => $shipment->get_status(),
+			'tracking_id'           => $shipment->get_tracking_id(),
+			'tracking_url'          => $shipment->get_tracking_url(),
+			'shipping_provider'     => $shipment->get_shipping_provider(),
+			'dimensions'            => array(
+				'length' => $shipment->get_length( $context ),
+				'width'  => $shipment->get_width( $context ),
+				'height' => $shipment->get_height( $context ),
+			),
+			'address'               => $shipment->get_address( $context ),
+			'items'                 => $item_data,
+		);
+	}
+
+	/**
+	 * Get the schema of a single shipment
+	 *
+	 * @return array
+	 */
+	public static function get_single_item_schema(): array {
+		$weight_unit    = get_option( 'woocommerce_weight_unit' );
+		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+
+		return array(
+			'description' => _x( 'Single shipment.', 'shipment', 'woocommerce-germanized-shipments' ),
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => false,
+			'type'        => 'object',
+			'properties'  => array(
+				'id'                    => array(
+					'description' => _x( 'Shipment ID.', 'shipments', 'woocommerce-germanized-shipments' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'status'                => array(
+					'description' => _x( 'Shipment status.', 'shipments', 'woocommerce-germanized-shipments' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'enum'        => self::get_shipment_statuses(),
+					'readonly'    => true,
+				),
+				'tracking_id'           => array(
+					'description' => _x( 'Shipment tracking id.', 'shipments', 'woocommerce-germanized-shipments' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'tracking_url'          => array(
+					'description' => _x( 'Shipment tracking url.', 'shipments', 'woocommerce-germanized-shipments' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'shipping_provider'     => array(
+					'description' => _x( 'Shipment shipping provider.',
+						'shipments',
+						'woocommerce-germanized-shipments' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_created'          => array(
+					'description' => _x(
+						"The date the shipment was created, in the site's timezone.",
+						'shipments',
+						'woocommerce-germanized-shipments'
+					),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_created_gmt'      => array(
+					'description' => _x(
+						'The date the shipment was created, as GMT.',
+						'shipments',
+						'woocommerce-germanized-shipments'
+					),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_sent'             => array(
+					'description' => _x(
+						"The date the shipment was sent, in the site's timezone.",
+						'shipments',
+						'woocommerce-germanized-shipments'
+					),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_sent_gmt'         => array(
+					'description' => _x(
+						'The date the shipment was sent, as GMT.',
+						'shipments',
+						'woocommerce-germanized-shipments'
+					),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'est_delivery_date'     => array(
+					'description' => _x(
+						"The estimated delivery date of the shipment, in the site's timezone.",
+						'shipments',
+						'woocommerce-germanized-shipments'
+					),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'est_delivery_date_gmt' => array(
+					'description' => _x(
+						'The estimated delivery date of the shipment, as GMT.',
+						'shipments',
+						'woocommerce-germanized-shipments'
+					),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'weight'                => array(
+					/* translators: %s: weight unit */
+					'description' => sprintf(
+						_x( 'Shipment weight (%s).', 'shipments', 'woocommerce-germanized-shipments' ),
+						$weight_unit
+					),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'dimensions'            => array(
+					'description' => _x( 'Shipment dimensions.', 'shipments', 'woocommerce-germanized-shipments' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+					'properties'  => array(
+						'length' => array(
+							/* translators: %s: dimension unit */
+							'description' => sprintf(
+								_x( 'Shipment length (%s).', 'shipments', 'woocommerce-germanized-shipments' ),
+								$dimension_unit
+							),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'width'  => array(
+							/* translators: %s: dimension unit */
+							'description' => sprintf(
+								_x( 'Shipment width (%s).', 'shipments', 'woocommerce-germanized-shipments' ),
+								$dimension_unit
+							),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'height' => array(
+							/* translators: %s: dimension unit */
+							'description' => sprintf(
+								_x( 'Shipment height (%s).', 'shipments', 'woocommerce-germanized-shipments' ),
+								$dimension_unit
+							),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+					),
+				),
+				'address'               => array(
+					'description' => _x( 'Shipping address.', 'shipments', 'woocommerce-germanized-shipments' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+					'properties'  => array(
+						'first_name' => array(
+							'description' => _x( 'First name.', 'shipments', 'woocommerce-germanized-shipments' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'last_name'  => array(
+							'description' => _x( 'Last name.', 'shipments', 'woocommerce-germanized-shipments' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'company'    => array(
+							'description' => _x( 'Company name.', 'shipments', 'woocommerce-germanized-shipments' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'address_1'  => array(
+							'description' => _x( 'Address line 1', 'shipments', 'woocommerce-germanized-shipments' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'address_2'  => array(
+							'description' => _x( 'Address line 2', 'shipments', 'woocommerce-germanized-shipments' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'city'       => array(
+							'description' => _x( 'City name.', 'shipments', 'woocommerce-germanized-shipments' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'state'      => array(
+							'description' => _x(
+								'ISO code or name of the state, province or district.',
+								'shipments',
+								'woocommerce-germanized-shipments'
+							),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'postcode'   => array(
+							'description' => _x( 'Postal code.', 'shipments', 'woocommerce-germanized-shipments' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'country'    => array(
+							'description' => _x(
+								'Country code in ISO 3166-1 alpha-2 format.',
+								'shipments',
+								'woocommerce-germanized-shipments'
+							),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+					),
+				),
+				'items'                 => array(
+					'description' => _x( 'Shipment items.', 'shipments', 'woocommerce-germanized-shipments' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'            => array(
+								'description' => _x( 'Item ID.', 'shipments', 'woocommerce-germanized-shipments' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'name'          => array(
+								'description' => _x( 'Item name.', 'shipments', 'woocommerce-germanized-shipments' ),
+								'type'        => 'mixed',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'order_item_id' => array(
+								'description' => _x( 'Order Item ID.',
+									'shipments',
+									'woocommerce-germanized-shipments' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'product_id'    => array(
+								'description' => _x( 'Product ID.', 'shipments', 'woocommerce-germanized-shipments' ),
+								'type'        => 'mixed',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'quantity'      => array(
+								'description' => _x( 'Quantity.', 'shipments', 'woocommerce-germanized-shipments' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+						),
+					),
+				),
+			),
+		);
+	}
 
 }

--- a/src/Rest/ShipmentsController.php
+++ b/src/Rest/ShipmentsController.php
@@ -1,0 +1,470 @@
+<?php
+
+namespace Vendidero\Germanized\Shipments\Rest;
+
+use Vendidero\Germanized\Shipments\Shipment;
+use WC_REST_Controller;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+class ShipmentsController extends WC_REST_Controller
+{
+
+    /**
+     * Endpoint namespace.
+     *
+     * @var string
+     */
+    protected $namespace = 'wc/v3';
+
+    /**
+     * Route base.
+     *
+     * @var string
+     */
+    protected $rest_base = 'orders/(?P<order_id>[\d]+)/shipments';
+
+    /**
+     * Registers rest routes for this controller.
+     */
+    public function register_routes()
+    {
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base,
+            array(
+                array(
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => array( $this, 'get_items' ),
+                    'permission_callback' => array( $this, 'get_items_permissions_check' ),
+                    'args'                => $this->get_collection_params(),
+                ),
+                'schema' => array( $this, 'get_public_item_schema' ),
+            ),
+        );
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base . '/(?P<id>[\d]+)',
+            array(
+                array(
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => array( $this, 'get_item' ),
+                    'permission_callback' => array( $this, 'get_item_permissions_check' ),
+                    'args'                => array(
+                        'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+                    ),
+                ),
+                array(
+                    'methods'             => WP_REST_Server::EDITABLE,
+                    'callback'            => array( $this, 'update_item' ),
+                    'permission_callback' => array( $this, 'update_item_permissions_check' ),
+                    'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+                ),
+                'schema' => array( $this, 'get_public_item_schema' ),
+            ),
+        );
+    }
+
+    private static function get_shipment_statuses() {
+        $statuses = array();
+
+        foreach ( array_keys( wc_gzd_get_shipment_statuses() ) as $status ) {
+            $statuses[] = str_replace( 'gzd-', '', $status );
+        }
+
+        return $statuses;
+    }
+
+    /**
+     * Checks if a given request has access to get a specific item.
+     *
+     * @since 4.7.0
+     *
+     * @param WP_REST_Request $request Full details about the request.
+     * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+     */
+    public function get_item_permissions_check($request)
+    {
+        return true;
+    }
+
+    /**
+     * Retrieves one item from the collection.
+     *
+     * @since 4.7.0
+     *
+     * @param WP_REST_Request $request Full details about the request.
+     * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+     */
+    public function get_item($request)
+    {
+        $order = wc_get_order((int)$request['order_id']);
+
+        $shipment = null;
+        if ($order) {
+            $order_shipment = wc_gzd_get_shipment_order($order);
+            $shipment = $order_shipment->get_shipment((int)$request['id']);
+            if (!$shipment) {
+                $shipment = new WP_Error(404, 'Not found');
+            } else {
+                $shipment = self::prepare_shipment($shipment);
+            }
+        }
+
+        $response = rest_ensure_response( $shipment );
+
+        return $response;
+    }
+
+    /**
+     * Checks if a given request has access to get a specific item.
+     *
+     * @since 4.7.0
+     *
+     * @param WP_REST_Request $request Full details about the request.
+     * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+     */
+    public function get_items_permissions_check($request)
+    {
+        return true;
+    }
+
+    /**
+     * Retrieves a collection of items.
+     *
+     * @since 4.7.0
+     *
+     * @param WP_REST_Request $request Full details about the request.
+     * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+     */
+    public function get_items($request)
+    {
+        $order = wc_get_order((int)$request['order_id']);
+
+        $result = array();
+        if ($order) {
+            $order_shipment = wc_gzd_get_shipment_order($order);
+            $shipments = $order_shipment->get_shipments();
+
+            if ( ! empty( $shipments ) ) {
+
+                foreach( $shipments as $shipment ) {
+                    $result[] = $this->prepare_shipment($shipment);
+                }
+            }
+        }
+
+        $response = rest_ensure_response( $result );
+
+        return $response;
+    }
+
+    /**
+     * Checks if a given request has access to update a specific item.
+     *
+     * @since 4.7.0
+     *
+     * @param WP_REST_Request $request Full details about the request.
+     * @return true|WP_Error True if the request has access to update the item, WP_Error object otherwise.
+     */
+    public function update_item_permissions_check($request)
+    {
+        return true;
+    }
+
+    /**
+     * Updates one item from the collection.
+     *
+     * @since 4.7.0
+     *
+     * @param WP_REST_Request $request Full details about the request.
+     * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+     */
+    public function update_item($request)
+    {
+    }
+
+    /**
+     * Retrieves the item's schema, conforming to JSON Schema.
+     *
+     * @since 4.7.0
+     *
+     * @return array Item schema data.
+     */
+    public function get_item_schema() {
+        return $this->add_additional_fields_schema(self::get_single_item_schema());
+    }
+
+    /**
+     * @param Shipment $shipment
+     *
+     * @return array
+     */
+    public static function prepare_shipment(Shipment $shipment, string $context = 'view', $dp = false): array {
+        $item_data = array();
+
+        foreach( $shipment->get_items() as $item ) {
+            $item_data[] = array(
+                'id'            => $item->get_id(),
+                'name'          => $item->get_name( $context ),
+                'order_item_id' => $item->get_order_item_id( $context ),
+                'product_id'    => $item->get_product_id( $context ),
+                'quantity'      => $item->get_quantity( $context ),
+            );
+        }
+
+        return array(
+            'id'                    => $shipment->get_id(),
+            'date_created'          => wc_rest_prepare_date_response( $shipment->get_date_created( $context ), false ),
+            'date_created_gmt'      => wc_rest_prepare_date_response( $shipment->get_date_created( $context ) ),
+            'date_sent'             => wc_rest_prepare_date_response( $shipment->get_date_sent( $context ), false ),
+            'date_sent_gmt'         => wc_rest_prepare_date_response( $shipment->get_date_sent( $context ) ),
+            'est_delivery_date'     => wc_rest_prepare_date_response( $shipment->get_est_delivery_date( $context ), false ),
+            'est_delivery_date_gmt' => wc_rest_prepare_date_response( $shipment->get_est_delivery_date( $context ) ),
+            'total'                 => wc_format_decimal( $shipment->get_total(), $dp ),
+            'weight'                => $shipment->get_weight( $context ),
+            'status'                => $shipment->get_status(),
+            'tracking_id'           => $shipment->get_tracking_id(),
+            'tracking_url'          => $shipment->get_tracking_url(),
+            'shipping_provider'     => $shipment->get_shipping_provider(),
+            'dimensions'            => array(
+                'length' => $shipment->get_length( $context ),
+                'width'  => $shipment->get_width( $context ),
+                'height' => $shipment->get_height( $context ),
+            ),
+            'address'               => $shipment->get_address( $context ),
+            'items'                 => $item_data,
+        );
+    }
+
+    /**
+     * Get the schema of a single shipment
+     *
+     * @return array
+     */
+    public static function get_single_item_schema(): array
+    {
+        $weight_unit    = get_option( 'woocommerce_weight_unit' );
+        $dimension_unit = get_option( 'woocommerce_dimension_unit' );
+
+        return array(
+            'description' => _x( 'Single shipment.', 'shipment', 'woocommerce-germanized-shipments' ),
+            'context'     => array( 'view', 'edit' ),
+            'readonly'    => false,
+            'type'       => 'object',
+            'properties' => array(
+                'id'     => array(
+                    'description' => _x( 'Shipment ID.', 'shipments', 'woocommerce-germanized-shipments' ),
+                    'type'        => 'integer',
+                    'context'     => array( 'view', 'edit' ),
+                    'readonly'    => true,
+                ),
+                'status' => array(
+                    'description' => _x( 'Shipment status.', 'shipments', 'woocommerce-germanized-shipments' ),
+                    'type'        => 'string',
+                    'context'     => array( 'view', 'edit' ),
+                    'enum'        => self::get_shipment_statuses(),
+                    'readonly'    => true,
+                ),
+                'tracking_id' => array(
+                    'description' => _x( 'Shipment tracking id.', 'shipments', 'woocommerce-germanized-shipments' ),
+                    'type'        => 'string',
+                    'context'     => array( 'view', 'edit' ),
+                    'readonly'    => true,
+                ),
+                'tracking_url' => array(
+                    'description' => _x( 'Shipment tracking url.', 'shipments', 'woocommerce-germanized-shipments' ),
+                    'type'        => 'string',
+                    'context'     => array( 'view', 'edit' ),
+                    'readonly'    => true,
+                ),
+                'shipping_provider' => array(
+                    'description' => _x( 'Shipment shipping provider.', 'shipments', 'woocommerce-germanized-shipments' ),
+                    'type'        => 'string',
+                    'context'     => array( 'view', 'edit' ),
+                    'readonly'    => true,
+                ),
+                'date_created'         => array(
+                    'description' => _x( "The date the shipment was created, in the site's timezone.", 'shipments', 'woocommerce-germanized-shipments' ),
+                    'type'        => 'date-time',
+                    'context'     => array( 'view', 'edit' ),
+                    'readonly'    => true,
+                ),
+                'date_created_gmt'     => array(
+                    'description' => _x( 'The date the shipment was created, as GMT.', 'shipments', 'woocommerce-germanized-shipments' ),
+                    'type'        => 'date-time',
+                    'context'     => array( 'view', 'edit' ),
+                    'readonly'    => true,
+                ),
+                'date_sent'         => array(
+                    'description' => _x( "The date the shipment was sent, in the site's timezone.", 'shipments', 'woocommerce-germanized-shipments' ),
+                    'type'        => 'date-time',
+                    'context'     => array( 'view', 'edit' ),
+                    'readonly'    => true,
+                ),
+                'date_sent_gmt'     => array(
+                    'description' => _x( 'The date the shipment was sent, as GMT.', 'shipments', 'woocommerce-germanized-shipments' ),
+                    'type'        => 'date-time',
+                    'context'     => array( 'view', 'edit' ),
+                    'readonly'    => true,
+                ),
+                'est_delivery_date' => array(
+                    'description' => _x( "The estimated delivery date of the shipment, in the site's timezone.", 'shipments', 'woocommerce-germanized-shipments' ),
+                    'type'        => 'date-time',
+                    'context'     => array( 'view', 'edit' ),
+                    'readonly'    => true,
+                ),
+                'est_delivery_date_gmt'     => array(
+                    'description' => _x( 'The estimated delivery date of the shipment, as GMT.', 'shipments', 'woocommerce-germanized-shipments' ),
+                    'type'        => 'date-time',
+                    'context'     => array( 'view', 'edit' ),
+                    'readonly'    => true,
+                ),
+                'weight'                => array(
+                    /* translators: %s: weight unit */
+                    'description' => sprintf( _x( 'Shipment weight (%s).', 'shipments', 'woocommerce-germanized-shipments' ), $weight_unit ),
+                    'type'        => 'string',
+                    'context'     => array( 'view', 'edit' ),
+                    'readonly'    => true,
+                ),
+                'dimensions'            => array(
+                    'description' => _x( 'Shipment dimensions.', 'shipments', 'woocommerce-germanized-shipments' ),
+                    'type'        => 'object',
+                    'context'     => array( 'view', 'edit' ),
+                    'readonly'    => true,
+                    'properties'  => array(
+                        'length' => array(
+                            /* translators: %s: dimension unit */
+                            'description' => sprintf( _x( 'Shipment length (%s).', 'shipments', 'woocommerce-germanized-shipments' ), $dimension_unit ),
+                            'type'        => 'string',
+                            'context'     => array( 'view', 'edit' ),
+                            'readonly'    => true,
+                        ),
+                        'width'  => array(
+                            /* translators: %s: dimension unit */
+                            'description' => sprintf( _x( 'Shipment width (%s).', 'shipments', 'woocommerce-germanized-shipments' ), $dimension_unit ),
+                            'type'        => 'string',
+                            'context'     => array( 'view', 'edit' ),
+                            'readonly'    => true,
+                        ),
+                        'height' => array(
+                            /* translators: %s: dimension unit */
+                            'description' => sprintf( _x( 'Shipment height (%s).', 'shipments', 'woocommerce-germanized-shipments' ), $dimension_unit ),
+                            'type'        => 'string',
+                            'context'     => array( 'view', 'edit' ),
+                            'readonly'    => true,
+                        ),
+                    ),
+                ),
+                'address'         => array(
+                    'description' => _x( 'Shipping address.', 'shipments', 'woocommerce-germanized-shipments' ),
+                    'type'        => 'object',
+                    'context'     => array( 'view', 'edit' ),
+                    'readonly'    => true,
+                    'properties'  => array(
+                        'first_name' => array(
+                            'description' => _x( 'First name.', 'shipments', 'woocommerce-germanized-shipments' ),
+                            'type'        => 'string',
+                            'context'     => array( 'view', 'edit' ),
+                            'readonly'    => true,
+                        ),
+                        'last_name'  => array(
+                            'description' => _x( 'Last name.', 'shipments', 'woocommerce-germanized-shipments' ),
+                            'type'        => 'string',
+                            'context'     => array( 'view', 'edit' ),
+                            'readonly'    => true,
+                        ),
+                        'company'    => array(
+                            'description' => _x( 'Company name.', 'shipments', 'woocommerce-germanized-shipments' ),
+                            'type'        => 'string',
+                            'context'     => array( 'view', 'edit' ),
+                            'readonly'    => true,
+                        ),
+                        'address_1'  => array(
+                            'description' => _x( 'Address line 1', 'shipments', 'woocommerce-germanized-shipments' ),
+                            'type'        => 'string',
+                            'context'     => array( 'view', 'edit' ),
+                            'readonly'    => true,
+                        ),
+                        'address_2'  => array(
+                            'description' => _x( 'Address line 2', 'shipments', 'woocommerce-germanized-shipments' ),
+                            'type'        => 'string',
+                            'context'     => array( 'view', 'edit' ),
+                            'readonly'    => true,
+                        ),
+                        'city'       => array(
+                            'description' => _x( 'City name.', 'shipments', 'woocommerce-germanized-shipments' ),
+                            'type'        => 'string',
+                            'context'     => array( 'view', 'edit' ),
+                            'readonly'    => true,
+                        ),
+                        'state'      => array(
+                            'description' => _x( 'ISO code or name of the state, province or district.', 'shipments', 'woocommerce-germanized-shipments' ),
+                            'type'        => 'string',
+                            'context'     => array( 'view', 'edit' ),
+                            'readonly'    => true,
+                        ),
+                        'postcode'   => array(
+                            'description' => _x( 'Postal code.', 'shipments', 'woocommerce-germanized-shipments' ),
+                            'type'        => 'string',
+                            'context'     => array( 'view', 'edit' ),
+                            'readonly'    => true,
+                        ),
+                        'country'    => array(
+                            'description' => _x( 'Country code in ISO 3166-1 alpha-2 format.', 'shipments', 'woocommerce-germanized-shipments' ),
+                            'type'        => 'string',
+                            'context'     => array( 'view', 'edit' ),
+                            'readonly'    => true,
+                        ),
+                    ),
+                ),
+                'items'           => array(
+                    'description' => _x( 'Shipment items.', 'shipments', 'woocommerce-germanized-shipments' ),
+                    'type'        => 'array',
+                    'context'     => array( 'view', 'edit' ),
+                    'readonly'    => true,
+                    'items'       => array(
+                        'type'       => 'object',
+                        'properties' => array(
+                            'id'           => array(
+                                'description' => _x( 'Item ID.', 'shipments', 'woocommerce-germanized-shipments' ),
+                                'type'        => 'integer',
+                                'context'     => array( 'view', 'edit' ),
+                                'readonly'    => true,
+                            ),
+                            'name'         => array(
+                                'description' => _x( 'Item name.', 'shipments', 'woocommerce-germanized-shipments' ),
+                                'type'        => 'mixed',
+                                'context'     => array( 'view', 'edit' ),
+                                'readonly'    => true,
+                            ),
+                            'order_item_id'   => array(
+                                'description' => _x( 'Order Item ID.', 'shipments', 'woocommerce-germanized-shipments' ),
+                                'type'        => 'integer',
+                                'context'     => array( 'view', 'edit' ),
+                                'readonly'    => true,
+                            ),
+                            'product_id'   => array(
+                                'description' => _x( 'Product ID.', 'shipments', 'woocommerce-germanized-shipments' ),
+                                'type'        => 'mixed',
+                                'context'     => array( 'view', 'edit' ),
+                                'readonly'    => true,
+                            ),
+                            'quantity'     => array(
+                                'description' => _x( 'Quantity.', 'shipments', 'woocommerce-germanized-shipments' ),
+                                'type'        => 'integer',
+                                'context'     => array( 'view', 'edit' ),
+                                'readonly'    => true,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        );
+    }
+
+}

--- a/tests/Framework/UnitRestTestCase.php
+++ b/tests/Framework/UnitRestTestCase.php
@@ -4,6 +4,9 @@ namespace Vendidero\Germanized\Shipments\Tests\Framework;
 
 class UnitRestTestCase extends UnitTestCase {
 
+	/**
+	 * @var \WP_Test_Spy_REST_Server
+	 */
 	protected $server;
 
 	/**

--- a/tests/Helpers/ShipmentHelper.php
+++ b/tests/Helpers/ShipmentHelper.php
@@ -21,6 +21,8 @@ class ShipmentHelper {
 
 	/**
 	 * Create simple shipment.
+	 *
+	 * @return \Vendidero\Germanized\Shipments\Shipment|\WP_Error
 	 */
 	public static function create_simple_shipment( $props = array(), $items = array() ) {
 

--- a/tests/unit-tests/Rest/ShipmentsControllerTest.php
+++ b/tests/unit-tests/Rest/ShipmentsControllerTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Rest;
+
+use Vendidero\Germanized\Shipments\Rest\ShipmentsController;
+use Vendidero\Germanized\Shipments\Tests\Helpers\ShipmentHelper;
+use WP_REST_Request;
+
+/**
+ * Class ShipmentsControllerTest
+ *
+ * Implements unit tests for shipments controller (rest api)
+ *
+ * @package Rest
+ */
+class ShipmentsControllerTest extends \Vendidero\Germanized\Shipments\Tests\Framework\UnitRestTestCase {
+
+	/**
+	 * Endpoint to test
+	 *
+	 * @var ShipmentsController
+	 */
+	private $endpoint;
+
+	/**
+	 * @var int
+	 */
+	private $user;
+
+	/**
+	 * Setup our test server, endpoints, and user info.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->endpoint = new ShipmentsController();
+		$this->user     = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+	}
+
+	/**
+	 * Tests reading one shipment from rest api.
+	 */
+	function test_get_shipment() {
+		wp_set_current_user( $this->user );
+
+		$shipment_initial = ShipmentHelper::create_simple_shipment();
+
+		$response          = $this->server->dispatch( new WP_REST_Request( 'GET',
+			'/wc/v3/shipments/' . $shipment_initial->get_id() ) );
+		$shipment_response = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$this->check_single_shipment( $shipment_response );
+	}
+
+	/**
+	 * Tests updating one shipment via rest api
+	 */
+	public function test_update_shipment() {
+		wp_set_current_user( $this->user );
+
+		$shipment_initial = ShipmentHelper::create_simple_shipment();
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/shipments/' . $shipment_initial->get_id() );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( array( 'status' => 'processing' ) ) );
+
+		$response        = $this->server->dispatch( $request );
+		$update_response = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response          = $this->server->dispatch( new WP_REST_Request( 'GET',
+			'/wc/v3/shipments/' . $shipment_initial->get_id() ) );
+		$shipment_response = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'processing', $update_response['status'] );
+		$this->assertEquals( 'processing', $shipment_response['status'] );
+	}
+
+	/**
+	 * Tests deleting one shipment via rest api
+	 */
+	public function test_delete_shipment() {
+		wp_set_current_user( $this->user );
+
+		$shipment_initial = ShipmentHelper::create_simple_shipment();
+
+		$request = new WP_REST_Request( 'DELETE', '/wc/v3/shipments/' . $shipment_initial->get_id() );
+
+		$response        = $this->server->dispatch( $request );
+		$delete_response = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 0, $delete_response['id'] );
+
+		$response          = $this->server->dispatch( new WP_REST_Request( 'GET',
+			'/wc/v3/shipments/' . $shipment_initial->get_id() ) );
+		$shipment_response = $response->get_data();
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Tests shipment lists
+	 */
+	public function test_list_shipments() {
+		wp_set_current_user( $this->user );
+
+		ShipmentHelper::create_simple_shipment();
+		ShipmentHelper::create_simple_shipment();
+		ShipmentHelper::create_simple_shipment();
+
+		$response           = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/shipments' ) );
+		$shipments_response = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 3, count( $shipments_response ) );
+
+		foreach ( $shipments_response as $shipment ) {
+			$this->check_single_shipment( $shipment );
+		}
+	}
+
+	/**
+	 * Checks validity of single shipment
+	 *
+	 * @param array $shipment
+	 */
+	private function check_single_shipment( $shipment ) {
+		$this->assertEquals( '40', $shipment['total'] );
+		$this->assertEquals( '4.4', $shipment['weight'] );
+		$this->assertEquals( 'draft', $shipment['status'] );
+		$this->assertEquals( array(
+			'length' => '25',
+			'width'  => '17.5',
+			'height' => '10',
+		), $shipment['dimensions'] );
+		$this->assertEquals( array(
+			'first_name' => 'Max',
+			'last_name'  => 'Mustermann',
+			'company'    => '',
+			'address_1'  => 'Musterstr. 12',
+			'address_2'  => '',
+			'city'       => 'Berlin',
+			'state'      => '',
+			'postcode'   => '12222',
+			'country'    => 'DE',
+			'phone'      => '555-32123',
+			'email'      => 'admin@example.org',
+		), $shipment['address'] );
+		$this->assertEquals( 1, count( $shipment['items'] ) );
+		$this->assertEquals( 'Dummy Product', $shipment['items'][0]['name'] );
+	}
+
+}


### PR DESCRIPTION
Created a ShipmentsController for the REST API, which can be used to solely retrieve all or specific shipments of a given order (identified by its id). The ShipmentsController also implements the update_item method so, that all relevant changeable shipment fields can be updated. It respects, if default values (or better to say content values) are still unchanged.

Please review my code and let me know if there are any required changes to this :)