### PR TITLE
Explicitly specify which table "shipment id" column

### DIFF
--- a/src/ShipmentQuery.php
+++ b/src/ShipmentQuery.php
@@ -500,9 +500,9 @@ class ShipmentQuery extends WC_Object_Query {
 
 		foreach ( $cols as $col ) {
 			if ( 'ID' === $col ) {
-				$searches[] = $wpdb->prepare( "$col = %s", $string ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$searches[] = $wpdb->prepare( "$wpdb->gzd_shipments.$col = %s", $string ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			} else {
-				$searches[] = $wpdb->prepare( "$col LIKE %s", $like ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$searches[] = $wpdb->prepare( "$wpdb->gzd_shipments.$col LIKE %s", $like ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			}
 		}
 


### PR DESCRIPTION
Hello, @dennisnissle! I found some issues when testing it on my local environment. So the main problem is when I filter products on the shipment page, I get the result only after double searching. The first request response is an empty page, and the second work fine.

And also when I make the first request I get this error on my debug.log file.
`WordPress database error Column 'shipment_id' in where clause is ambiguous for query SELECT SQL_CALC_FOUND_ROWS wp_uyyncooagm_woocommerce_gzd_shipments.* FROM wp_uyyncooagm_woocommerce_gzd_shipments JOIN wp_uyyncooagm_woocommerce_gzd_shipment_items as shipment_items ON ( shipment_items.shipment_id = wp_uyyncooagm_woocommerce_gzd_shipments.shipment_id )  WHERE 1=1 AND shipment_items.shipment_item_product_id IN (2339) AND (shipment_type = 'simple') AND (shipment_status = 'gzd-draft' OR shipment_status = 'gzd-processing' OR shipment_status = 'gzd-shipped' OR shipment_status = 'gzd-delivered' OR shipment_status = 'gzd-requested' OR shipment_status = 'gzd-transferred') AND (shipment_id LIKE '%%' OR shipment_country LIKE '%%' OR shipment_tracking_id LIKE '%%' OR shipment_order_id LIKE '%%' OR shipment_search_index LIKE '%%') ORDER BY shipment_date_created DESC LIMIT 0, 200 made by do_action('load-woocommerce_page_wc-gzd-shipments'), WP_Hook->do_action, WP_Hook->apply_filters, Vendidero\Germanized\Shipments\Admin\Admin::setup_shipments_table, Vendidero\Germanized\Shipments\Admin\Admin::setup_table, Vendidero\Germanized\Shipments\Admin\Table->prepare_items, Vendidero\Germanized\Shipments\ShipmentQuery->get_shipments, Vendidero\Germanized\Shipments\ShipmentQuery->query`

It's related to the next problem.

**The error message states that the column shipment_id is ambiguous, which means that it's not clear which table the shipment_id column should be selected from in the query. Looking at the query, there are two tables being joined: **wp_uyyncooagm_woocommerce_gzd_shipments** and **wp_uyyncooagm_woocommerce_gzd_shipment_items**. Both of these tables have a column named **shipment_id.****


So this code should fix this issue and I also tested it on my local environment.

Btw, when I tested it the first time I added the product id to `$args` manually, and the search worked fine. But in the case of select, we have this issue. 