### PR TITLE
Use pre initialized classes for bulk action handlers

### DIFF
--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -1554,7 +1554,7 @@ class Admin {
 
 			foreach ( $handlers as $key => $handler ) {
 
-				if ( is_object( $handler ) && is_a( $handler, get_class( $handler ) ) ) {
+				if ( is_object( $handler ) && is_a( $handler, 'Vendidero\Germanized\Shipments\Admin\BulkActionHandler' ) ) {
 					self::$bulk_handlers[ $key ] = $handler;
 					continue;
 				}

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -1553,6 +1553,12 @@ class Admin {
 			);
 
 			foreach ( $handlers as $key => $handler ) {
+
+				if ( is_object( $handler ) && is_a( $handler, get_class( $handler ) ) ) {
+					self::$bulk_handlers[ $key ] = $handler;
+					continue;
+				}
+
 				self::$bulk_handlers[ $key ] = new $handler();
 			}
 		}


### PR DESCRIPTION
Hi there 👋

With this change I want to achieve that we can use pre initialized classes for bulk action handlers and that we don't have to reinitialize them. This would be good if we want to create dynamic/reusable bulk actions and pass dynamic arguments to it:

![code](https://github.com/vendidero/woocommerce-germanized-shipments/assets/55055484/86f7a27a-d4e0-4c87-b3e2-17fe51fb65e6)

If you have any questions, please let me know.

Have a nice day!