### PR TITLE
feat: Maked possible filter shipments by order ids

### DIFF
--- a/src/ShipmentQuery.php
+++ b/src/ShipmentQuery.php
@@ -178,7 +178,8 @@ class ShipmentQuery extends WC_Object_Query {
 	 */
 	protected function parse_query() {
 		if ( isset( $this->args['order_id'] ) ) {
-			$this->args['order_id'] = absint( $this->args['order_id'] );
+			$this->args['order_id'] = (array) $this->args['order_id'];
+			$this->args['order_id'] = array_map( 'absint', $this->args['order_id'] );
 		}
 
 		if ( isset( $this->args['shipping_provider'] ) ) {
@@ -284,7 +285,9 @@ class ShipmentQuery extends WC_Object_Query {
 
 		// order id
 		if ( isset( $this->args['order_id'] ) ) {
-			$this->query_where .= $wpdb->prepare( ' AND shipment_order_id = %d', $this->args['order_id'] );
+			$order_ids = array_map( 'absint', $this->args['order_id'] );
+			$placeholders = implode( ',', array_fill( 0, count( $order_ids ), '%d' ) );
+			$this->query_where .= $wpdb->prepare( " AND shipment_order_id IN ({$placeholders})", ...$order_ids );
 		}
 
 		// order id


### PR DESCRIPTION
Dear @dennisnissle,

I've made some updates to the ShipmentQuery class for better handling of `order_id` values.

**Here’s a brief overview:**

Enhanced Support for Multiple Order IDs:

The class can now process an array of order_ids. This allows fetching shipments for several orders simultaneously.
For safety and efficiency, the code uses array_map and implode to construct SQL query placeholders.
Adaptability for Single or Multiple Order IDs:

order_id can now be a single value or an array. This makes ShipmentQuery more adaptable to different use cases.
The implementation involves casting to an array and sanitizing with absint.

These updates aim to make ShipmentQuery more versatile and secure in handling order IDs. I've tested these changes to ensure they align with our standards and requirements.

Please review and let me know if any adjustments are needed.

Best regards,
Max