### PR TITLE
Improve search query check

### DIFF
--- a/src/Admin/Table.php
+++ b/src/Admin/Table.php
@@ -355,7 +355,7 @@ class Table extends WP_List_Table {
 			}
 		}
 
-		if ( isset( $_REQUEST['s'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! empty( $_REQUEST['s'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$search = wc_clean( wp_unslash( $_REQUEST['s'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 			if ( ! is_numeric( $search ) ) {


### PR DESCRIPTION
Hi there,

with this change I want to improve the check when `$_REQUEST['s']` is empty.

Right now, by using `isset()` the search argument gets `**` around it and with `! empty()` not.
I think this makes more sense because we had a bug when using custom filters (eg. search for suppliers) the **empty** search input gets sent too and parsed (-> `**`).

If you have any questions, let me know! 🚀